### PR TITLE
Update breakpoints to prevent vanishing controls

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     build: ./
     volumes:
       - ./node:/usr/app
-    depends_on: 
+    depends_on:
       - postgres
     environment:
       - PGUSER=postgres

--- a/react/src/Components/Dashboard/Dashboard.tsx
+++ b/react/src/Components/Dashboard/Dashboard.tsx
@@ -187,7 +187,6 @@ const LearnMoreSection: React.FC = () => (
                 .
             </Text>
         </OutlinedColumn>
-        <Column xs={0} md={6}></Column>
     </Row>
 );
 

--- a/react/src/Components/Dashboard/DisplayControls/DisplayControls.tsx
+++ b/react/src/Components/Dashboard/DisplayControls/DisplayControls.tsx
@@ -93,7 +93,7 @@ const DisplayControls: React.FC<{ maxHeight?: number }> = ({ maxHeight }) => {
 
     return (
         <>
-            <Column xs={6}>
+            <Column xs={12} lg={6}>
                 {(!!activeFeatures.length || !!userAnnotationDomain.length) && (
                     <>
                         <WidgetTitle
@@ -187,7 +187,6 @@ const DisplayControls: React.FC<{ maxHeight?: number }> = ({ maxHeight }) => {
                         maxHeight={maxHeight ? +maxHeight / 4 : undefined}
                     />
                 </Row>
-
                 <Row>
                     <DisplaySettings />
                 </Row>
@@ -236,7 +235,7 @@ const DisplayControls: React.FC<{ maxHeight?: number }> = ({ maxHeight }) => {
                     </Column>
                 </Row>
             </Column>
-            <Column xs={6}>
+            <Column xs={12} lg={6}>
                 <Row>
                     <PanelContainer>
                         <AnnotationControls />

--- a/react/src/Components/Dashboard/DisplayControls/Legend.tsx
+++ b/react/src/Components/Dashboard/DisplayControls/Legend.tsx
@@ -120,7 +120,7 @@ const LegendItemContainer = styled.span`
 const LinearLegendContainer = styled.div`
     cursor: pointer;
     height: 25px;
-    width: 200px;
+    width: 150px;
 `;
 
 const LinearLegendLabel = styled(Text)`

--- a/react/src/Components/Input.tsx
+++ b/react/src/Components/Input.tsx
@@ -18,7 +18,7 @@ export const Input = styled.input<InputProps>`
     color: ${props => props.theme.palette.grey};
     padding: 0.75em 0.5em;
     margin-left: ${props => props.ml ?? 'inherit'};
-    max-width: ${props => props.width ?? '200px'};
+    width: ${props => props.width ?? '100%'};
 `;
 
 //typing is bad for reuse via attrs.as, so we'll just copy/paste for now
@@ -35,7 +35,7 @@ export const TextArea = styled.textarea<InputProps>`
     color: ${props => props.theme.palette.grey};
     padding: 0.75em 0.5em;
     margin-left: ${props => props.ml ?? 'inherit'};
-    max-width: ${props => props.width ?? '200px'};
+    max-width: ${props => props.width ?? '100%'};
 `;
 
 interface NumberInputProps extends InputProps {
@@ -51,6 +51,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
     onChange,
     ml,
     value,
+    width,
 }) => {
     const [internalValue, setInternalValue] = useState<
         number | string | undefined
@@ -82,6 +83,7 @@ export const NumberInput: React.FC<NumberInputProps> = ({
             ml={ml}
             onChange={e => wrappedOnChange(e.currentTarget.value)}
             value={internalValue}
+            width={width}
         />
     );
 };

--- a/react/src/Components/Layout.tsx
+++ b/react/src/Components/Layout.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import theme from '../theme';
 import QuestionTip from './QuestionTip';
 import { Caption, Title } from './Typography';
 
@@ -14,10 +15,15 @@ const media = {
         flex-basis: ${(cols / 12) * 100 - 2}%;
     `,
     md: (cols: number) => `
-        @media only screen and (min-width: 1238px) {
+        @media only screen and (min-width: ${theme.breakpoints.md}) {
             flex-basis: ${(cols / 12) * 100 - 2}%;
         }
     `,
+    lg: (cols: number) => `
+        @media only screen and (min-width: ${theme.breakpoints.lg}) {
+            flex-basis: ${(cols / 12) * 100 - 2}%;
+        }
+`,
 };
 
 interface ColProps extends RowProps {
@@ -38,6 +44,7 @@ export const Column = styled.div<ColProps>`
     }
     ${props => media.xs(props.xs)}
     ${props => props.md && media.md(props.md)}
+    ${props => props.lg && media.lg(props.lg)}
 `;
 
 export const Row = styled.div<RowProps>`

--- a/react/src/theme.ts
+++ b/react/src/theme.ts
@@ -10,8 +10,8 @@ const theme = {
         white: '#ffffff',
     },
     breakpoints: {
-        lg: '1200px',
-        md: '900px',
+        md: '600px',
+        lg: '900px',
     },
 };
 


### PR DESCRIPTION
closes #13 
- use horizontal layout with 2-column controls on screens > 900px (most laptop/desktop/tablets)
- use horizontal layout with 1-column controls on screens > 600px & < 900px (landscape phones)
- use vertical layout with 1-column controls on screens < 600px (narrow browser windows, portrait phones)


![gt900](https://github.com/schwartzlab-methods/too-many-cells-interactive/assets/12862284/7ab9a1e9-ddd8-4b73-9ace-e9e658363606)
![gt600lt900](https://github.com/schwartzlab-methods/too-many-cells-interactive/assets/12862284/8998fbe9-0499-4d12-ba97-153f40b55dfc)
![lt600](https://github.com/schwartzlab-methods/too-many-cells-interactive/assets/12862284/f1216bba-ddaa-44ef-9618-2682055d6abc)
