### PR TITLE
Modified binSize

### DIFF
--- a/react/src/hooks/usePrunedTree.ts
+++ b/react/src/hooks/usePrunedTree.ts
@@ -590,11 +590,11 @@ const getMadGroups = (values: number[], binCount = 15, maxSize?: number) => {
     // assume that max is greater than median...
     const greatestPositiveMadDistance = valueToMadCount(max || 0, med, mad);
 
-    const binSize =
-        Math.abs(
-            Math.abs(greatestPositiveMadDistance) -
-                Math.abs(greatestNegativeMadDistance)
-        ) / binCount;
+    // greatestPositiveMadDistance is >= 0 by def.
+    // greatestNegativeMadDistance is <= 0 by def.
+    // Therefore binSize is guaranteed to be >= 0.
+    const binSize = (greatestPositiveMadDistance -
+                greatestNegativeMadDistance) / binCount;
 
     return range(
         greatestNegativeMadDistance,
@@ -609,7 +609,7 @@ const getMadGroups = (values: number[], binCount = 15, maxSize?: number) => {
 /**
  * Get the median and MAD(s) for a feature distribution in the tree
  * @param {TMCHierarchyDataNode} node The tree
- * @param {string} feature The featuer
+ * @param {string} feature The feature
  * @returns {object}
  */
 export const getFeatureMadAndMeds = (

--- a/react/src/hooks/usePrunedTree.ts
+++ b/react/src/hooks/usePrunedTree.ts
@@ -593,8 +593,8 @@ const getMadGroups = (values: number[], binCount = 15, maxSize?: number) => {
     // greatestPositiveMadDistance is >= 0 by def.
     // greatestNegativeMadDistance is <= 0 by def.
     // Therefore binSize is guaranteed to be >= 0.
-    const binSize = (greatestPositiveMadDistance -
-                greatestNegativeMadDistance) / binCount;
+    const binSize =
+        (greatestPositiveMadDistance - greatestNegativeMadDistance) / binCount;
 
     return range(
         greatestNegativeMadDistance,


### PR DESCRIPTION
I am doing some computations with the MAD and I noticed a discrepancy between my results and TMCI. I think the issue starts in line 593 of https://github.com/schwartzlab-methods/too-many-cells-interactive/blob/main/react/src/hooks/usePrunedTree.ts#L593
If Math.abs(greatestPositiveMadDistance) == Math.abs(greatestNegativeMadDistance), then the binSize becomes zero. For example, if the expression vector is v = [0,1,2], then the median is v_med = 1, v-v_med = [-1,0,1], and abs(v-v_med) = [1,0,1]. Hence, v_MAD = median(abs(v-v_med)) = median([1,0,1]) = 1. Finally, since (v - v_med) / v_MAD = [-1, 0, 1], in this case the condition  Math.abs(greatestPositiveMadDistance) == Math.abs(greatestNegativeMadDistance), which is equivalent to |-1| == |1|, is satisfied and the binSize becomes zero.
 
Please let me know if you agree.

Thanks,

Javier

